### PR TITLE
7 minecraft server volume is linked to a randomly generated directery by k3s

### DIFF
--- a/kubernetes/external/minecraft/servers/minecraft-helm-base.yaml
+++ b/kubernetes/external/minecraft/servers/minecraft-helm-base.yaml
@@ -66,11 +66,15 @@ extraEnv:
   # WARNING: setting this to true deletes your previous world data
   FORCE_WORLD_COPY: false
 
-# required to save the world in persistent local-path storage (k3s default Storage Class)
-# by default this goes in /var/lib/rancher/k3s/storage on the executing node.
-# NOTE this ties the deployment to the first node it spins up on,
-# TODO: use an NFS mount to avoid this
+# This bounds the server to a PVC, making it easier to provide a storage while avoiding k3s to put the volume in his dir
+# Downside is that you need to chown the volume mount if you put the directory on the Node like me
+# example: sudo chown 1000:3000 -R /mnt/volume-minecraft-base
 persistence:
   dataDir:
     enabled: true
     existingClaim: pvc-minecraft-base
+
+# Check above
+podSecurityContext:
+  runAsGroup: 3000
+  fsGroup: 3000

--- a/kubernetes/external/minecraft/servers/minecraft-helm-base.yaml
+++ b/kubernetes/external/minecraft/servers/minecraft-helm-base.yaml
@@ -73,4 +73,4 @@ extraEnv:
 persistence:
   dataDir:
     enabled: true
-    Size: 20Gi
+    existingClaim: pvc-minecraft-base

--- a/kubernetes/external/minecraft/servers/playzir.yaml
+++ b/kubernetes/external/minecraft/servers/playzir.yaml
@@ -39,3 +39,7 @@ persistence:
   dataDir:
     enabled: true
     existingClaim: pvc-playzir
+
+podSecurityContext:
+  runAsGroup: 3000
+  fsGroup: 3000

--- a/kubernetes/external/minecraft/servers/playzir.yaml
+++ b/kubernetes/external/minecraft/servers/playzir.yaml
@@ -38,4 +38,4 @@ extraEnv:
 persistence:
   dataDir:
     enabled: true
-    Size: 20Gi
+    existingClaim: pvc-playzir

--- a/kubernetes/external/minecraft/volumes/volume-minecraft-base.yaml
+++ b/kubernetes/external/minecraft/volumes/volume-minecraft-base.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-minecraft-base
+  labels:
+    type: local
+spec:
+  storageClassName: storage-minecraft-base
+  capacity:
+    storage: 30Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/mnt/pv-minecraft-base"
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-minecraft-base
+spec:
+  storageClassName: storage-minecraft-base
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 3Gi

--- a/kubernetes/external/minecraft/volumes/volume-playzir.yaml
+++ b/kubernetes/external/minecraft/volumes/volume-playzir.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-playzir
+  labels:
+    type: local
+spec:
+  storageClassName: storage-playzir
+  capacity:
+    storage: 30Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/mnt/pv-playzir"
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-playzir
+spec:
+  storageClassName: storage-playzir
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 3Gi


### PR DESCRIPTION
# Description

Fixes issue https://github.com/Sentrance/k3s-gameservers/issues/7

Now instead of a PV managed by k3s with a non-existing (maybe?) PVC, we explicitly create a PV/PVC and use it in our minecraft server pod.

Note that since we set the minecraft server group as non root, we need to `chown ` the mounted volume (because mounted volumes are root owned by default).
I added comments in the example file.